### PR TITLE
Remove acl usage

### DIFF
--- a/.github/workflows/campfire-deploy.yaml
+++ b/.github/workflows/campfire-deploy.yaml
@@ -81,7 +81,7 @@ jobs:
           aws s3api put-public-access-block \
           --bucket campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io \
           --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
-          aws s3api put-bucket-policy --bucket your-bucket-name --policy "{
+          aws s3api put-bucket-policy --bucket campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io --policy "{
           \"Version\": \"2012-10-17\",
           \"Statement\": [
               {
@@ -89,7 +89,7 @@ jobs:
                   \"Effect\": \"Allow\",
                   \"Principal\": \"*\",
                   \"Action\": \"s3:GetObject\",
-                  \"Resource\": \"arn:aws:s3:::your-bucket-name/*\"
+                  \"Resource\": \"arn:aws:s3:::campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io/*\"
               }
           ]
           }"

--- a/.github/workflows/campfire-deploy.yaml
+++ b/.github/workflows/campfire-deploy.yaml
@@ -78,9 +78,24 @@ jobs:
         run: |
           aws s3api head-bucket --bucket campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io || aws s3 mb s3://campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io --region us-west-2
           sleep 20 && aws s3 website s3://campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io/ --index-document index.html --error-document index.html
+          aws s3api put-public-access-block \
+          --bucket campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io \
+          --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+          aws s3api put-bucket-policy --bucket your-bucket-name --policy "{
+          \"Version\": \"2012-10-17\",
+          \"Statement\": [
+              {
+                  \"Sid\": \"PublicReadGetObject\",
+                  \"Effect\": \"Allow\",
+                  \"Principal\": \"*\",
+                  \"Action\": \"s3:GetObject\",
+                  \"Resource\": \"arn:aws:s3:::your-bucket-name/*\"
+              }
+          ]
+          }"
 
       - name: Deploy to S3
-        run: aws s3 sync ./packages/isomorphic-next/out s3://campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io  --delete --acl public-read
+        run: aws s3 sync ./packages/isomorphic-next/out s3://campfire-${{ steps.lower-name.outputs.lowercase }}.userpilot.io  --delete
 
       - name: Create cloudflare record
         uses: rez0n/create-dns-record@v2.1


### PR DESCRIPTION
Amazon recently remove ACL usage for S3 buckets, so our deployments are failing because of that. this PR removes the ACL usage and updates the buket-policy directly instead